### PR TITLE
Make sure that ranger colorschemes directory exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,4 +19,5 @@ EOF
   fi
 fi
 
-cp -v ranger/isene.py "$ranger_colorscheme_dir"
+mkdir -pv "$ranger_colorscheme_dir"
+cp -v ranger/isene.py "$ranger_colorscheme_dir/isene.py"


### PR DESCRIPTION
When `$HOME/.config/ranger/colorschemes` directory doesn't exist instead of copying `isene.py` to `$HOME/.config/ranger/colorschemes/isene.py` it is copied to `$HOME/.config/ranger/colorschemes`, i.e `colorschemes` becomes a file, not a directory and that crashes ranger.